### PR TITLE
Fix build with Go 1.24

### DIFF
--- a/mclib.go
+++ b/mclib.go
@@ -23,7 +23,7 @@ func RunMain() (err error) {
 		if r := recover(); r != nil {
 			errStr := fmt.Sprintf("%v", r)
 			errStr = errorReplacer.Replace(errStr)
-			err = fmt.Errorf(errStr)
+			err = fmt.Errorf("%s", errStr)
 		}
 	}()
 


### PR DESCRIPTION
Go 1.24 provides stricter checking that forbids passing a variable as a format string to Printf-like functions with no other arguments. Remove instances of this. See also:

https://tip.golang.org/doc/go1.24#vet